### PR TITLE
Add DevMedia to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curated list of companies using php in production
 * [Dafiti](https://www.dafiti.com.br) | São Paulo, Brazil
 * [DataDog](https://www.datadoghq.com/) | New York, USA; Paris, France; Dublin, Ireland; Remote
 * [DB1](https://www.db1.com.br/) | Maringá, Brazil
+* [DevMedia](https://www.devmedia.com.br/) | Rio de Janeiro, Brazil
 * [Docler Holding](https://doclerholding.recruitee.com/) |Luxembourg, Luxembourg
 * [E-goi](https://mkt.e-goi.com/) | Londrina, Brazil
 * [Easy Taxi](http://easytaxi.com.br) | São Paulo, Brazil


### PR DESCRIPTION
I add DevMedia to the php jobs list
DevMedia is a brazilian platform focused on teaching programming 👨‍💻
#hacktoberfest